### PR TITLE
Move ext-pcntl from require to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     "license": "MIT",
     "homepage": "https://github.com/arthurkushman/php-wss",
     "require": {
-        "php": ">=7.4",
-        "ext-pcntl": "*"
+        "php": ">=7.4"
     },
     "autoload": {
         "psr-4": {
@@ -33,5 +32,8 @@
         "monolog/monolog": "^1.24",
         "phpstan/phpstan": "^1.4",
         "phpbench/phpbench": "^1.2"
+    },
+    "suggest": {
+        "ext-pcntl": "Allows for forking the server process to handle more clients at once"
     }
 }


### PR DESCRIPTION
The server works without `ext-pcntl` so the extension should be suggested rather than required.

Additionally, the client doesn't make any use of the extension.

Currently I'm installing the package with the below in `composer.json` to work around the requirement.

```json
"replace": {
    "ext-pcntl": "*"
}
```