### PR TITLE
Avoid to iterate too fast on server looping and protect CPU usage

### DIFF
--- a/src/WebSocketServer.php
+++ b/src/WebSocketServer.php
@@ -52,6 +52,11 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
     private bool $stepRecursion = true;
 
     /**
+     * @var int
+     */
+    private int $loopingDelay = 1000;
+
+    /**
      * WebSocketServer constructor.
      *
      * @param WebSocket $handler
@@ -67,6 +72,18 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
         $this->handler = $handler;
         $this->config = $config;
         $this->setIsPcntlLoaded(extension_loaded('pcntl'));
+    }
+
+    /**
+     * Set the looping sleep in microseconds
+     *
+     * @return self
+     */
+    public function loopingDelay(int $loopingDelay): self
+    {
+        $this->loopingDelay = $loopingDelay;
+
+        return $this;
     }
 
     /**
@@ -139,7 +156,7 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
     private function looping($server): void
     {
         while (true) {
-            usleep(1000);
+            usleep($this->loopingDelay);
 
             $totalClients = count($this->clients) + 1;
 

--- a/src/WebSocketServer.php
+++ b/src/WebSocketServer.php
@@ -139,6 +139,8 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
     private function looping($server): void
     {
         while (true) {
+            usleep(1000);
+
             $totalClients = count($this->clients) + 1;
 
             // maxClients prevents process fork on count down


### PR DESCRIPTION
Maybe related with https://github.com/arthurkushman/php-wss/issues/73

I have also a high CPU usage once the remote clients are connected to websocket server.

Adding a 0.001 seconds delay on every server loop iteration can reduce about a 90% the CPU usage without appreciable loss of performance.

Also can be changed to 0.01 seconds delay to reduce about a 99% de CPU usage without appreciable performance loss.

Maybe a `loopDelay` method is a better idea?