### PR TITLE
Avoid to iterate too fast on server looping and protect CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,21 @@ $websocketServer = new WebSocketServer(new ServerHandler(), $config);
 $websocketServer->run();
 ```
 
+### Avoid high CPU usage
+```php
+use WSSC\WebSocketServer;
+use WSSCTEST\ServerHandler;
+use WSSC\Components\ServerConfig;
+
+$config = new ServerConfig();
+
+// Set the read socket iteration delay in miliseconds
+$config->setLoopingDelay(1);
+
+$webSocketServer = new WebSocketServer(new ServerHandler(), $config);
+$webSocketServer->run();
+```
+
 ### How to test
 
 To run the Server - execute from the root of a project:

--- a/src/Components/ServerConfig.php
+++ b/src/Components/ServerConfig.php
@@ -2,6 +2,7 @@
 
 namespace WSSC\Components;
 
+use Exception;
 use WSSC\Contracts\WebSocketServerContract;
 
 class ServerConfig
@@ -46,7 +47,6 @@ class ServerConfig
      */
     private array $origins = [];
 
-
     /**
      * @var bool
      */
@@ -76,6 +76,16 @@ class ServerConfig
      * @var int
      */
     private int $cryptoType;
+
+    /**
+     * @var int
+     */
+    private int $loopingDelay = 0;
+
+    /**
+     * @var array
+     */
+    private array $loopingDelayRange = [0, 1000];
 
     /**
      * @return int
@@ -329,5 +339,29 @@ class ServerConfig
     public function getCryptoType(): int
     {
         return $this->cryptoType;
+    }
+
+    /**
+     * Set the looping sleep in milliseconds
+     *
+     * @return self
+     */
+    public function setLoopingDelay(int $loopingDelay): self
+    {
+        if (($loopingDelay < $this->loopingDelayRange[0]) || ($loopingDelay > $this->loopingDelayRange[1])) {
+            throw new Exception('loopingDelay value must be between 1 and 1000 milliseconds.');
+        }
+
+        $this->loopingDelay = $loopingDelay;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLoopingDelay(): int
+    {
+        return $this->loopingDelay;
     }
 }

--- a/src/WebSocketServer.php
+++ b/src/WebSocketServer.php
@@ -51,11 +51,7 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
      */
     private bool $stepRecursion = true;
 
-    /**
-     * @var int
-     */
-    private int $loopingDelay = 1000;
-
+    /*
      * @var bool
      */
     private bool $printException = true;
@@ -76,18 +72,6 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
         $this->handler = $handler;
         $this->config = $config;
         $this->setIsPcntlLoaded(extension_loaded('pcntl'));
-    }
-
-    /**
-     * Set the looping sleep in microseconds
-     *
-     * @return self
-     */
-    public function loopingDelay(int $loopingDelay): self
-    {
-        $this->loopingDelay = $loopingDelay;
-
-        return $this;
     }
 
     /**
@@ -171,8 +155,13 @@ class WebSocketServer extends WssMain implements WebSocketServerContract
      */
     private function looping($server): void
     {
+        $loopingDelay = $this->config->getLoopingDelay();
+
         while (true) {
-            usleep($this->loopingDelay);
+            // usleep require microseconds
+            if ($loopingDelay) {
+                usleep($loopingDelay * 1000);
+            }
 
             $totalClients = count($this->clients) + 1;
 

--- a/tests/WebSocketServerTest.php
+++ b/tests/WebSocketServerTest.php
@@ -20,6 +20,7 @@ class WebSocketServerTest extends TestCase
         $config = new ServerConfig();
         $config->setClientsPerFork(2500);
         $config->setStreamSelectTimeout(2 * 3600);
+        $config->setLoopingDelay(1);
 
         $websocketServer = new WebSocketServer(new ServerHandler(), $config);
         $websocketServer->run();


### PR DESCRIPTION
Maybe related with https://github.com/arthurkushman/php-wss/issues/73

I have also a high CPU usage once the remote clients are connected to websocket server.

Adding a 0.001 seconds delay on every server loop iteration can reduce about a 90% the CPU usage without appreciable loss of performance.

Also can be changed to 0.01 seconds delay to reduce about a 99% de CPU usage without appreciable performance loss.